### PR TITLE
fix file path and missing input in mutate-genomes-gdtools.smk

### DIFF
--- a/src/brefito/workflow/rules/mutate-genomes-gdtools.smk
+++ b/src/brefito/workflow/rules/mutate-genomes-gdtools.smk
@@ -22,5 +22,5 @@ rule mutate_genomes_gdtools:
     threads: 8
     shell:
         """
-        gdtools APPLY -o {output} {params.reference_arguments} -f GFF3 {input.genomediff} > {log} 2>&1
+        gdtools APPLY -o {output} {params.reference_arguments} -f GFF3 {input.genomediff} -r {input.references} > {log} 2>&1
         """

--- a/src/brefito/workflow/rules/mutate-genomes-gdtools.smk
+++ b/src/brefito/workflow/rules/mutate-genomes-gdtools.smk
@@ -9,7 +9,7 @@ rule all_mutate_genomes_gdtools:
 
 rule mutate_genomes_gdtools:
     input:
-        genomediff = "genome_diffs/{sample}.gd",
+        genomediff = "genome-diffs/{sample}.gd",
         references = lambda wildcards: sample_info.get_reference_list(wildcards.sample)
     output:
         "mutants/{sample}.gff3"


### PR DESCRIPTION
Minor fixes: 
1. changed file path from genome_diff to genome-diff in `brefito/src/brefito/workflow/rules/mutate-genomes-gdtools.smk`
2. added the missing reference -r parameter that should be passed to gdtools APPLY